### PR TITLE
feat: add dollarbox repo to unicornops github org

### DIFF
--- a/github/unicornops/repos/dollarbox/terragrunt.hcl
+++ b/github/unicornops/repos/dollarbox/terragrunt.hcl
@@ -1,0 +1,33 @@
+terraform {
+  source = "tfr:///mineiros-io/repository/github?version=0.18.0"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "github" {
+  owner = "${local.org_vars.github_owner}"
+}
+terraform {
+  backend "s3" {}
+}
+EOF
+}
+
+locals {
+  org_vars  = yamldecode(file(find_in_parent_folders("org.yaml")))
+  repo_name = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  name                 = local.repo_name
+  vulnerability_alerts = true
+  visibility           = "private"
+  description          = "Repo for the dollarbox project"
+  has_issues           = true
+}


### PR DESCRIPTION
## Summary

- Adds a new private GitHub repository called `dollarbox` to the UnicornOps GitHub org
- Configured with vulnerability alerts and issues enabled, following the same pattern as other repos in the org

## Test plan

- [ ] Verify Terragrunt plan succeeds for `github/unicornops/repos/dollarbox`
- [ ] Confirm repo is created in the UnicornOps GitHub org after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)