### PR TITLE
feat: add dollarbox cloudflare pages site to unicornops

### DIFF
--- a/cloudflare/unicornops/sites/dollarbox/terragrunt.hcl
+++ b/cloudflare/unicornops/sites/dollarbox/terragrunt.hcl
@@ -1,0 +1,33 @@
+terraform {
+  source = "github.com/lazzurs/terraform-cloudflare-pages-github?ref=v0.1.0"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Indicate what region to deploy the resources into
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  backend "s3" {}
+}
+EOF
+}
+
+locals {
+  project_name = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  build_command                    = "curl -sL https://github.com/getzola/zola/releases/download/v0.19.2/zola-v0.19.2-x86_64-unknown-linux-gnu.tar.gz | tar xz && cp -r theme website/static/ && ./zola --root website build"
+  destination_dir                  = "website/public"
+  root_dir                         = "/"
+  project_name                     = local.project_name
+  github_repo_name                 = local.project_name
+  preview_environment_variables    = {}
+  production_environment_variables = {}
+  production_branch                = "main"
+}


### PR DESCRIPTION
## Summary

- Adds a new Cloudflare Pages site config for `dollarbox` under the unicornops account
- Uses repo root (`/`) as the root directory so the `theme/` directory is accessible during build
- Build command installs Zola v0.19.2, copies the theme into `website/static/`, then builds
- Output directory set to `website/public`
- No environment variables configured for v1

## Test plan

- [ ] Verify terragrunt plan applies cleanly against the unicornops Cloudflare account
- [ ] Confirm Cloudflare Pages project is created with production branch `main`
- [ ] Confirm build succeeds end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)