### PR TITLE
feat: add github actions workflows for cloudflare unicornops terragrunt

### DIFF
--- a/.github/workflows/cloudflare_unicornops_apply.yml
+++ b/.github/workflows/cloudflare_unicornops_apply.yml
@@ -1,0 +1,60 @@
+---
+name: Cloudflare Unicornops Apply
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "cloudflare/unicornops/**"
+      - ".github/workflows/cloudflare_unicornops_apply.yml"
+
+jobs:
+  terragrunt_apply:
+    runs-on: ubuntu-latest
+    name: Run Terragrunt Apply for Cloudflare Unicornops
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v2
+        with:
+          tofu_version: 1.8.1
+
+      - name: Setup Terragrunt
+        run: |
+          wget https://github.com/gruntwork-io/terragrunt/releases/download/v0.67.16/terragrunt_linux_amd64
+          chmod +x terragrunt_linux_amd64
+          sudo mv terragrunt_linux_amd64 /usr/local/bin/terragrunt
+          terragrunt --version
+
+      - name: Run Terragrunt Apply
+        working-directory: ./cloudflare/unicornops
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_UNICORNOPS_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TERRAGRUNT_GITHUB_API_TOKEN }}
+        run: |
+          terragrunt run-all apply --terragrunt-non-interactive
+
+      - name: Create Issue on Failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Cloudflare Unicornops Apply Failed - ${context.sha.substring(0, 7)}`,
+              body: `❌ Terragrunt apply failed for commit ${context.sha}\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nPlease check the logs for details.`,
+              labels: ['terragrunt', 'deployment-failure']
+            })

--- a/.github/workflows/cloudflare_unicornops_plan.yml
+++ b/.github/workflows/cloudflare_unicornops_plan.yml
@@ -1,0 +1,59 @@
+---
+name: Cloudflare Unicornops Plan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "cloudflare/unicornops/**"
+      - ".github/workflows/cloudflare_unicornops_plan.yml"
+
+jobs:
+  terragrunt_plan:
+    runs-on: ubuntu-latest
+    name: Run Terragrunt Plan for Cloudflare Unicornops
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v2
+        with:
+          tofu_version: 1.8.1
+
+      - name: Setup Terragrunt
+        run: |
+          wget https://github.com/gruntwork-io/terragrunt/releases/download/v0.67.16/terragrunt_linux_amd64
+          chmod +x terragrunt_linux_amd64
+          sudo mv terragrunt_linux_amd64 /usr/local/bin/terragrunt
+          terragrunt --version
+
+      - name: Run Terragrunt Plan
+        working-directory: ./cloudflare/unicornops
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_UNICORNOPS_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TERRAGRUNT_GITHUB_API_TOKEN }}
+        run: |
+          terragrunt run-all plan --terragrunt-non-interactive
+
+      - name: Comment PR with Plan Summary
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Terragrunt plan completed for `cloudflare/unicornops/` directory. Check the workflow logs for details.'
+            })


### PR DESCRIPTION
## Summary

- Adds `cloudflare_unicornops_plan.yml` workflow to run `terragrunt run-all plan` on PRs touching `cloudflare/unicornops/**`
- Adds `cloudflare_unicornops_apply.yml` workflow to run `terragrunt run-all apply` on merge to `main`
- Both workflows support manual triggering via `workflow_dispatch`

## Secrets required

- `CLOUDFLARE_UNICORNOPS_API_TOKEN` — Cloudflare API token with Pages Edit permission (already added)
- `MINIO_ACCESS_KEY_ID` / `MINIO_SECRET_ACCESS_KEY` — existing MinIO credentials for S3 state backend
- `TERRAGRUNT_GITHUB_API_TOKEN` — existing GitHub token for the Cloudflare Pages GitHub provider

## Test plan

- [ ] Manually trigger the plan workflow via Actions tab to verify Cloudflare credentials and MinIO backend are working
- [ ] Open a PR touching `cloudflare/unicornops/**` and confirm plan runs and comments on the PR
- [ ] Merge to `main` and confirm apply runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)