### PR TITLE
feat(axiom): add dollarbox production dataset and deploy workflows

### DIFF
--- a/.github/workflows/axiom_unicornops_apply.yml
+++ b/.github/workflows/axiom_unicornops_apply.yml
@@ -1,0 +1,59 @@
+---
+name: Axiom Unicornops Apply
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "axiom/unicornops/**"
+      - ".github/workflows/axiom_unicornops_apply.yml"
+
+jobs:
+  terragrunt_apply:
+    runs-on: ubuntu-latest
+    name: Run Terragrunt Apply for Axiom Unicornops
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v2
+        with:
+          tofu_version: 1.8.1
+
+      - name: Setup Terragrunt
+        run: |
+          wget https://github.com/gruntwork-io/terragrunt/releases/download/v0.67.16/terragrunt_linux_amd64
+          chmod +x terragrunt_linux_amd64
+          sudo mv terragrunt_linux_amd64 /usr/local/bin/terragrunt
+          terragrunt --version
+
+      - name: Run Terragrunt Apply
+        working-directory: ./axiom/unicornops
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_ACCESS_KEY }}
+          AXIOM_TOKEN: ${{ secrets.AXIOM_UNICORNOPS_API_TOKEN }}
+        run: |
+          terragrunt run-all apply --terragrunt-non-interactive
+
+      - name: Create Issue on Failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Axiom Unicornops Apply Failed - ${context.sha.substring(0, 7)}`,
+              body: `❌ Terragrunt apply failed for commit ${context.sha}\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nPlease check the logs for details.`,
+              labels: ['terragrunt', 'deployment-failure']
+            })

--- a/.github/workflows/axiom_unicornops_plan.yml
+++ b/.github/workflows/axiom_unicornops_plan.yml
@@ -1,0 +1,58 @@
+---
+name: Axiom Unicornops Plan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "axiom/unicornops/**"
+      - ".github/workflows/axiom_unicornops_plan.yml"
+
+jobs:
+  terragrunt_plan:
+    runs-on: ubuntu-latest
+    name: Run Terragrunt Plan for Axiom Unicornops
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v2
+        with:
+          tofu_version: 1.8.1
+
+      - name: Setup Terragrunt
+        run: |
+          wget https://github.com/gruntwork-io/terragrunt/releases/download/v0.67.16/terragrunt_linux_amd64
+          chmod +x terragrunt_linux_amd64
+          sudo mv terragrunt_linux_amd64 /usr/local/bin/terragrunt
+          terragrunt --version
+
+      - name: Run Terragrunt Plan
+        working-directory: ./axiom/unicornops
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_ACCESS_KEY }}
+          AXIOM_TOKEN: ${{ secrets.AXIOM_UNICORNOPS_API_TOKEN }}
+        run: |
+          terragrunt run-all plan --terragrunt-non-interactive
+
+      - name: Comment PR with Plan Summary
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Terragrunt plan completed for `axiom/unicornops/` directory. Check the workflow logs for details.'
+            })

--- a/axiom/unicornops/dev/aireach/terragrunt.hcl
+++ b/axiom/unicornops/dev/aireach/terragrunt.hcl
@@ -10,7 +10,9 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
-provider "axiom" {}
+provider "axiom" {
+  api_token = get_env("AXIOM_TOKEN")
+}
 
 terraform {
   backend "s3" {}

--- a/axiom/unicornops/dev/aireach/terragrunt.hcl
+++ b/axiom/unicornops/dev/aireach/terragrunt.hcl
@@ -11,7 +11,7 @@ generate "provider" {
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
 provider "axiom" {
-  api_token = get_env("AXIOM_TOKEN")
+  api_token = "${get_env("AXIOM_TOKEN")}"
 }
 
 terraform {

--- a/axiom/unicornops/dev/cloud-weather/terragrunt.hcl
+++ b/axiom/unicornops/dev/cloud-weather/terragrunt.hcl
@@ -10,7 +10,9 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
-provider "axiom" {}
+provider "axiom" {
+  api_token = get_env("AXIOM_TOKEN")
+}
 
 terraform {
   backend "s3" {}

--- a/axiom/unicornops/dev/cloud-weather/terragrunt.hcl
+++ b/axiom/unicornops/dev/cloud-weather/terragrunt.hcl
@@ -11,7 +11,7 @@ generate "provider" {
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
 provider "axiom" {
-  api_token = get_env("AXIOM_TOKEN")
+  api_token = "${get_env("AXIOM_TOKEN")}"
 }
 
 terraform {

--- a/axiom/unicornops/dev/family-chat/terragrunt.hcl
+++ b/axiom/unicornops/dev/family-chat/terragrunt.hcl
@@ -10,7 +10,9 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
-provider "axiom" {}
+provider "axiom" {
+  api_token = get_env("AXIOM_TOKEN")
+}
 
 terraform {
   backend "s3" {}

--- a/axiom/unicornops/dev/family-chat/terragrunt.hcl
+++ b/axiom/unicornops/dev/family-chat/terragrunt.hcl
@@ -11,7 +11,7 @@ generate "provider" {
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
 provider "axiom" {
-  api_token = get_env("AXIOM_TOKEN")
+  api_token = "${get_env("AXIOM_TOKEN")}"
 }
 
 terraform {

--- a/axiom/unicornops/prd/aireach/terragrunt.hcl
+++ b/axiom/unicornops/prd/aireach/terragrunt.hcl
@@ -10,7 +10,9 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
-provider "axiom" {}
+provider "axiom" {
+  api_token = get_env("AXIOM_TOKEN")
+}
 
 terraform {
   backend "s3" {}

--- a/axiom/unicornops/prd/aireach/terragrunt.hcl
+++ b/axiom/unicornops/prd/aireach/terragrunt.hcl
@@ -11,7 +11,7 @@ generate "provider" {
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
 provider "axiom" {
-  api_token = get_env("AXIOM_TOKEN")
+  api_token = "${get_env("AXIOM_TOKEN")}"
 }
 
 terraform {

--- a/axiom/unicornops/prd/dollarbox/main.tf
+++ b/axiom/unicornops/prd/dollarbox/main.tf
@@ -1,0 +1,8 @@
+variable "dataset_name" {
+  type        = string
+  description = "The name of the Axiom dataset"
+}
+
+resource "axiom_dataset" "this" {
+  name = var.dataset_name
+}

--- a/axiom/unicornops/prd/dollarbox/terragrunt.hcl
+++ b/axiom/unicornops/prd/dollarbox/terragrunt.hcl
@@ -1,0 +1,34 @@
+terraform {
+  source = "."
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "axiom" {}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    axiom = {
+      source = "axiomhq/axiom"
+      version = "1.5.0"
+    }
+  }
+}
+EOF
+}
+
+locals {
+  env_vars = yamldecode(file(find_in_parent_folders("env.yaml")))
+  basename = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  dataset_name = "${local.basename}-${local.env_vars.environment_name}"
+}

--- a/axiom/unicornops/prd/dollarbox/terragrunt.hcl
+++ b/axiom/unicornops/prd/dollarbox/terragrunt.hcl
@@ -10,7 +10,9 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
-provider "axiom" {}
+provider "axiom" {
+  api_token = get_env("AXIOM_TOKEN")
+}
 
 terraform {
   backend "s3" {}

--- a/axiom/unicornops/prd/dollarbox/terragrunt.hcl
+++ b/axiom/unicornops/prd/dollarbox/terragrunt.hcl
@@ -11,7 +11,7 @@ generate "provider" {
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
 provider "axiom" {
-  api_token = get_env("AXIOM_TOKEN")
+  api_token = "${get_env("AXIOM_TOKEN")}"
 }
 
 terraform {

--- a/axiom/unicornops/root.hcl
+++ b/axiom/unicornops/root.hcl
@@ -14,7 +14,7 @@ remote_state {
     skip_bucket_enforced_tls           = true
     skip_bucket_root_access            = true
     skip_credentials_validation        = true
-    use_path_style                     = true
+    force_path_style                   = true
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `axiom/unicornops/prd/dollarbox/` Terragrunt config to create the `dollarbox-prd` dataset in Axiom, following the same pattern as `aireach`
- Adds `axiom_unicornops_plan.yml` workflow — runs `terragrunt run-all plan` on pull requests touching `axiom/unicornops/**`
- Adds `axiom_unicornops_apply.yml` workflow — runs `terragrunt run-all apply` on merge to `main`, creates a GitHub issue on failure

## Secret required

Before this PR can apply successfully, add `AXIOM_UNICORNOPS_API_TOKEN` to the repo's GitHub Actions secrets (Settings → Secrets → Actions).

Get the token from Axiom → Settings → API Tokens — create one with **Ingest** + **Query** permissions scoped to the `unicornops` org.

## What gets created

| Resource | Value |
|---|---|
| Axiom dataset | `dollarbox-prd` |
| State key | `unicornops/prd/dollarbox/terraform.tfstate` |
| Backend | Minio (`unicornops-terragrunt-state-axiom`) |

## Related

- dollarbox app PR: unicornops/dollarbox#12 (Axiom logging wiring)
- Ansible PR: unicornops/ansible#21 (token in k8s secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)