### PR TITLE
feat(github): add dollarbox terraform provider repo

### DIFF
--- a/github/unicornops/repos/terraform-provider-dollarbox/terragrunt.hcl
+++ b/github/unicornops/repos/terraform-provider-dollarbox/terragrunt.hcl
@@ -1,0 +1,36 @@
+terraform {
+  source = "tfr:///mineiros-io/repository/github?version=0.18.0"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "github" {
+  owner = "${local.org_vars.github_owner}"
+}
+terraform {
+  backend "s3" {}
+}
+EOF
+}
+
+locals {
+  org_vars  = yamldecode(file(find_in_parent_folders("org.yaml")))
+  repo_name = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  name                 = local.repo_name
+  license_template     = "mpl-2.0"
+  gitignore_template   = "Go"
+  vulnerability_alerts = true
+  visibility           = "public"
+  description          = "Official Terraform provider for DollarBox"
+  has_issues           = true
+  has_wiki             = true
+}


### PR DESCRIPTION
## Summary

- Adds Terragrunt config for the public unicornops/terraform-provider-dollarbox repository.
- Uses the existing mineiros GitHub repository module pattern.
- Enables issues, wiki, vulnerability alerts, MPL-2.0 license template, and Go gitignore template.

Refs unicornops/dollarbox#105.

## Verification

- git diff --check
- git diff --cached --check
- GitHub PR checks passed

Terragrunt is not installed locally in this environment; the GitOps CI workflow ran the plan.