### PR TITLE
feat(github): add docker-dollarbox-cloudflare-example repo

### DIFF
--- a/github/unicornops/repos/docker-dollarbox-cloudflare-example/terragrunt.hcl
+++ b/github/unicornops/repos/docker-dollarbox-cloudflare-example/terragrunt.hcl
@@ -1,0 +1,34 @@
+terraform {
+  source = "tfr:///mineiros-io/repository/github?version=0.18.0"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "github" {
+  owner = "${local.org_vars.github_owner}"
+}
+terraform {
+  backend "s3" {}
+}
+EOF
+}
+
+locals {
+  org_vars  = yamldecode(file(find_in_parent_folders("org.yaml")))
+  repo_name = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  name                 = local.repo_name
+  vulnerability_alerts = true
+  visibility           = "public"
+  description          = "Example of using Docker with Dollarbox and Cloudflare"
+  has_issues           = true
+  has_wiki             = true
+}


### PR DESCRIPTION
Adds a new public GitHub repository under the unicornops org for the Docker Dollarbox Cloudflare example project.