### PR TITLE
feat(axiom): add dollarbox-k3s production dataset

### DIFF
--- a/axiom/unicornops/prd/dollarbox-k3s/main.tf
+++ b/axiom/unicornops/prd/dollarbox-k3s/main.tf
@@ -1,0 +1,8 @@
+variable "dataset_name" {
+  type        = string
+  description = "The name of the Axiom dataset"
+}
+
+resource "axiom_dataset" "this" {
+  name = var.dataset_name
+}

--- a/axiom/unicornops/prd/dollarbox-k3s/terragrunt.hcl
+++ b/axiom/unicornops/prd/dollarbox-k3s/terragrunt.hcl
@@ -1,0 +1,36 @@
+terraform {
+  source = "."
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "axiom" {
+  api_token = "${get_env("AXIOM_TOKEN")}"
+}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    axiom = {
+      source = "axiomhq/axiom"
+      version = "1.5.0"
+    }
+  }
+}
+EOF
+}
+
+locals {
+  env_vars = yamldecode(file(find_in_parent_folders("env.yaml")))
+  basename = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  dataset_name = "${local.basename}-${local.env_vars.environment_name}"
+}


### PR DESCRIPTION
## Summary
- Add Terragrunt/Terraform stack at `axiom/unicornops/prd/dollarbox-k3s/` to manage the `dollarbox-k3s-prd` Axiom dataset
- Follows the same pattern as the existing `prd/dollarbox` stack

## Test plan
- [ ] Verify `Axiom Unicornops Plan` workflow passes on this PR
- [ ] Merge and confirm `Axiom Unicornops Apply` succeeds on main


Made with [Cursor](https://cursor.com)