### PR TITLE
feat: add dollarbox-status repo and Cloudflare Pages project

### DIFF
--- a/cloudflare/unicornops/sites/dollarbox-status/terragrunt.hcl
+++ b/cloudflare/unicornops/sites/dollarbox-status/terragrunt.hcl
@@ -1,0 +1,32 @@
+terraform {
+  source = "github.com/lazzurs/terraform-cloudflare-pages-github?ref=v0.1.0"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  backend "s3" {}
+}
+EOF
+}
+
+locals {
+  project_name = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  build_command                    = ""
+  destination_dir                  = "."
+  root_dir                         = "/"
+  project_name                     = local.project_name
+  github_repo_name                 = local.project_name
+  preview_environment_variables    = {}
+  production_environment_variables = {}
+  production_branch                = "gh-pages"
+}

--- a/github/unicornops/repos/dollarbox-status/terragrunt.hcl
+++ b/github/unicornops/repos/dollarbox-status/terragrunt.hcl
@@ -1,0 +1,33 @@
+terraform {
+  source = "tfr:///mineiros-io/repository/github?version=0.18.0"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "github" {
+  owner = "${local.org_vars.github_owner}"
+}
+terraform {
+  backend "s3" {}
+}
+EOF
+}
+
+locals {
+  org_vars  = yamldecode(file(find_in_parent_folders("org.yaml")))
+  repo_name = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  name                 = local.repo_name
+  vulnerability_alerts = true
+  visibility           = "private"
+  description          = "Upptime status page for DollarBox"
+  has_issues           = true
+}


### PR DESCRIPTION
## Summary

- Adds `github/unicornops/repos/dollarbox-status/terragrunt.hcl` — private GitHub repo for the Upptime status page instance
- Adds `cloudflare/unicornops/sites/dollarbox-status/terragrunt.hcl` — Cloudflare Pages project connected to the `gh-pages` branch (Upptime pre-builds and pushes the static site there; watching `gh-pages` instead of `main` prevents a CF Pages build on every 5-minute monitoring commit)

## Test plan

- [ ] Terragrunt plan output shows two new resources: `github_repository.dollarbox-status` and `cloudflare_pages_project.dollarbox-status`
- [ ] Merge and apply; confirm `unicornops/dollarbox-status` repo exists on GitHub as private
- [ ] Confirm `dollarbox-status` project appears in Cloudflare Pages dashboard
- [ ] Initialize the repo from the Upptime template and add `GH_PAT` secret (see unicornops/dollarbox#237)

Refs unicornops/dollarbox#237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwtazGHxMMHxxqHU6nTR5d