### PR TITLE
feat: add status.dollarbox.dev custom domain to dollarbox-status CF Pages

### DIFF
--- a/cloudflare/unicornops/sites/dollarbox-status/terragrunt.hcl
+++ b/cloudflare/unicornops/sites/dollarbox-status/terragrunt.hcl
@@ -16,6 +16,18 @@ terraform {
 EOF
 }
 
+generate "domain" {
+  path      = "domain.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+resource "cloudflare_pages_domain" "custom" {
+  account_id   = var.cloudflare_account_id
+  project_name = "${local.project_name}"
+  domain       = "status.dollarbox.dev"
+}
+EOF
+}
+
 locals {
   project_name = basename(get_terragrunt_dir())
 }


### PR DESCRIPTION
Adds a `cloudflare_pages_domain` resource so CF Pages serves `status.dollarbox.dev` from the dollarbox-status project. DNS CNAME is already live (merged via octodns PR #36). Refs unicornops/dollarbox#237