### PR TITLE
chore(dollarbox-status): make repo public for Upptime status page

### DIFF
--- a/github/unicornops/repos/dollarbox-status/terragrunt.hcl
+++ b/github/unicornops/repos/dollarbox-status/terragrunt.hcl
@@ -27,7 +27,7 @@ locals {
 inputs = {
   name                 = local.repo_name
   vulnerability_alerts = true
-  visibility           = "private"
+  visibility           = "public"
   description          = "Upptime status page for DollarBox"
   has_issues           = true
 }


### PR DESCRIPTION
## Summary

- Changes `dollarbox-status` repo visibility from `private` to `public`

## Why

Upptime's status page client-side JavaScript reads from GitHub API and raw GitHub content without authentication (it runs in the browser). For private repos this returns 404, causing the status page to redirect to `/error` on load.

Making it public is Upptime's intended use case. The repo contains only uptime history YAML, workflow files using `github.token`, and public endpoint URLs — nothing sensitive.

## Test plan
- [ ] Apply Terragrunt — repo becomes public
- [ ] Verify `status.dollarbox.dev` loads correctly (no redirect to `/error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwtazGHxMMHxxqHU6nTR5d