### PR TITLE
feat(cloudflare): add familychat.dev zone for family-chat staging

### DIFF
--- a/cloudflare/unicornops/zones/familychat-dev/terragrunt.hcl
+++ b/cloudflare/unicornops/zones/familychat-dev/terragrunt.hcl
@@ -1,0 +1,71 @@
+# familychat.dev — dedicated zone for family-chat ephemeral staging.
+#
+# Deliberately a separate registrable domain (Cloudflare subdomain zones are
+# Enterprise-only): the staging CI token is scoped to this zone and cannot
+# touch the production safechat.family zone. See family-chat's
+# docs/staging-environment.md for the environment this serves.
+#
+# After first apply: point the registrar's nameservers at the name_servers
+# output, then copy zone_id into the family-chat repo's `staging` GitHub
+# environment as CLOUDFLARE_ZONE_ID.
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  backend "s3" {}
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+EOF
+}
+
+generate "main" {
+  path      = "main.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+variable "cloudflare_account_id" {
+  type = string
+}
+
+variable "zone_name" {
+  type = string
+}
+
+resource "cloudflare_zone" "this" {
+  account_id = var.cloudflare_account_id
+  zone       = var.zone_name
+  plan       = "free"
+}
+
+resource "cloudflare_zone_settings_override" "this" {
+  zone_id = cloudflare_zone.this.id
+
+  settings {
+    always_use_https = "on"
+    ssl              = "strict"
+  }
+}
+
+output "zone_id" {
+  value = cloudflare_zone.this.id
+}
+
+output "name_servers" {
+  value = cloudflare_zone.this.name_servers
+}
+EOF
+}
+
+inputs = {
+  zone_name = "familychat.dev"
+}

--- a/cloudflare/unicornops/zones/familychat-dev/terragrunt.hcl
+++ b/cloudflare/unicornops/zones/familychat-dev/terragrunt.hcl
@@ -13,6 +13,12 @@ include "root" {
   path = find_in_parent_folders("root.hcl")
 }
 
+# The zone is defined inline via the generate blocks below; the self-referencing
+# source is required for terragrunt run-all to discover this module.
+terraform {
+  source = "."
+}
+
 generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite_terragrunt"

--- a/dollarbox/README.md
+++ b/dollarbox/README.md
@@ -1,0 +1,33 @@
+# DollarBox accounts
+
+DollarBox orgs consumed by other UnicornOps projects. Org creation and comped
+billing are staff actions in the DollarBox control panel (deliberately not in
+the public API or the Terraform provider), so this directory records them as a
+register rather than as Terraform. Namespaces/containers *within* an org can
+be managed via [terraform-provider-dollarbox](https://github.com/unicornops/terraform-provider-dollarbox)
+if IaC is wanted later.
+
+## family-chat-staging
+
+Ephemeral staging for [family-chat](https://github.com/unicornops/family-chat)
+— see `docs/staging-environment.md` in that repo for the full runbook.
+
+- **Org**: `family-chat-staging`, comped via
+  `python manage.py grant_comped_billing family-chat-staging`
+- **Quota**: ≥ 20 containers / 60 GB storage (full e2e run ≈ 15 containers)
+- **Reserved IPv6**: ≥ 5 addresses in the org's `container-reserved-ipv6`
+  pool — 4 family homeserver LoadBalancers + 1 control-panel LB (the panel
+  address is pinned via the `K8S_PANEL_RESERVED_IPV6` GitHub secret)
+- **Credentials**: tenant kubeconfig stored as the `KUBECONFIG_STAGING`
+  secret in the family-chat repo's `staging` GitHub environment
+- **Rotation**: regenerate the tenant kubeconfig in the DollarBox panel and
+  update `KUBECONFIG_STAGING`; nothing else holds it. The org has no API
+  token by design (`DOLLARBOX_API_TOKEN` stays unset so the family-chat
+  control panel runs in single-namespace mode).
+
+## family-chat (production)
+
+Production family-chat also deploys onto a DollarBox tenant namespace (org
+managed separately; see `docs/dollarbox-deployment.md` in the family-chat
+repo). Recorded here for completeness — its credentials live in the
+family-chat repo's `production` GitHub environment.


### PR DESCRIPTION
Adds the dedicated `familychat.dev` Cloudflare zone for family-chat ephemeral staging (subdomain zones are Enterprise-only, hence a separate registrable domain), plus a register of the `family-chat-staging` comped DollarBox org.

On merge, the Cloudflare Unicornops Apply workflow creates the zone; the `name_servers` output goes to the registrar and `zone_id` becomes the `CLOUDFLARE_ZONE_ID` secret in family-chat's `staging` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gv4g5QrwxvAe1BcQF7PdvY