### PR TITLE
fix(cloudflare): drop zone settings override for familychat.dev

### DIFF
--- a/cloudflare/unicornops/zones/familychat-dev/terragrunt.hcl
+++ b/cloudflare/unicornops/zones/familychat-dev/terragrunt.hcl
@@ -53,14 +53,10 @@ resource "cloudflare_zone" "this" {
   plan       = "free"
 }
 
-resource "cloudflare_zone_settings_override" "this" {
-  zone_id = cloudflare_zone.this.id
-
-  settings {
-    always_use_https = "on"
-    ssl              = "strict"
-  }
-}
+# Zone settings are deliberately not managed here: cloudflare_zone_settings_override
+# reads every setting including entitlement-gated ones (origin_max_http_version ->
+# "Access denied (999)"). New zones default to Automatic SSL/TLS; always_use_https
+# is enabled at deploy time by family-chat's scripts/cloudflare-enable-always-https.sh.
 
 output "zone_id" {
   value = cloudflare_zone.this.id


### PR DESCRIPTION
The zone created successfully on the previous apply; the settings override failed with Cloudflare's Access denied (999) on entitlement-gated settings. Removing it — HTTPS settings are handled at deploy time like production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gv4g5QrwxvAe1BcQF7PdvY