### PR TITLE
ci(cloudflare): bump OpenTofu to 1.12.3 for removed block support

### DIFF
--- a/.github/workflows/cloudflare_unicornops_apply.yml
+++ b/.github/workflows/cloudflare_unicornops_apply.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:
-          tofu_version: 1.8.1
+          tofu_version: 1.12.3
 
       - name: Setup Terragrunt
         run: |

--- a/.github/workflows/cloudflare_unicornops_plan.yml
+++ b/.github/workflows/cloudflare_unicornops_plan.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:
-          tofu_version: 1.8.1
+          tofu_version: 1.12.3
 
       - name: Setup Terragrunt
         run: |


### PR DESCRIPTION
OpenTofu 1.8.1 rejects `removed` blocks (Unsupported block type), which blocks forgetting the familychat.dev zone settings override from state (#44). 1.12.3 validated locally against the same config. The PR plan run doubles as the compatibility check for the existing sites modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gv4g5QrwxvAe1BcQF7PdvY