### PR TITLE
feat: add gitops-environments repo configuration for unicornops

### DIFF
--- a/github/unicornops/repos/gitops-environments/terragrunt.hcl
+++ b/github/unicornops/repos/gitops-environments/terragrunt.hcl
@@ -1,0 +1,34 @@
+terraform {
+  source = "tfr:///mineiros-io/repository/github?version=0.18.0"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Indicate what region to deploy the resources into
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "github" {
+  owner = "${local.org_vars.github_owner}"
+}
+terraform {
+  backend "s3" {}
+}
+EOF
+}
+
+locals {
+  org_vars  = yamldecode(file(find_in_parent_folders("org.yaml")))
+  repo_name = basename(get_terragrunt_dir())
+}
+
+inputs = {
+  name                 = local.repo_name
+  vulnerability_alerts = true
+  visibility           = "private"
+  description          = "GitOps environments repository for managing infrastructure as code"
+  has_issues           = true
+}


### PR DESCRIPTION
Add Terragrunt configuration to create a private gitops-environments repository under the unicornops organization.

This PR adds the necessary Terragrunt configuration in the github/unicornops/repos/gitops-environments/ directory to manage a new private repository via IaC.

The terragrunt plan workflow will run automatically to validate the configuration before merge, and the apply workflow will create the actual GitHub repository after merge.